### PR TITLE
Accept application/javascript content-type for settings GET (fixes #8)

### DIFF
--- a/VWOFmeSdk.Tests/Internal/NetworkClientContentTypeTests.cs
+++ b/VWOFmeSdk.Tests/Internal/NetworkClientContentTypeTests.cs
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2024-2026 Wingify Software Pvt. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using WingifyFmeSdk.Packages.NetworkLayer.Client;
+using Xunit;
+
+namespace VWOFlagTesting.Tests
+{
+    public class NetworkClientContentTypeTests
+    {
+        // The settings endpoint responds with "application/json", while data-residency
+        // (region-prefixed) settings endpoints respond with "application/javascript" for the same
+        // JSON body. Both must be accepted so background settings polling succeeds.
+        // See https://github.com/wingify/vwo-fme-dotnet-sdk/issues/8
+        [Theory]
+        [InlineData("application/json")]
+        [InlineData("application/json; charset=UTF-8")]
+        [InlineData("application/javascript")]
+        [InlineData("application/javascript; charset=UTF-8")]
+        public void IsJsonCompatibleContentType_AcceptsJsonAndJavascript(string contentType)
+        {
+            Assert.True(NetworkClient.IsJsonCompatibleContentType(contentType));
+        }
+
+        [Theory]
+        [InlineData("text/html")]
+        [InlineData("text/plain")]
+        [InlineData("application/xml")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void IsJsonCompatibleContentType_RejectsNonJsonAndNull(string contentType)
+        {
+            Assert.False(NetworkClient.IsJsonCompatibleContentType(contentType));
+        }
+    }
+}

--- a/WingifyFmeSdk/Packages/NetworkLayer/Client/NetworkClient.cs
+++ b/WingifyFmeSdk/Packages/NetworkLayer/Client/NetworkClient.cs
@@ -86,6 +86,23 @@ namespace WingifyFmeSdk.Packages.NetworkLayer.Client
         }
 
         /// <summary>
+        /// Determines whether a response Content-Type carries a JSON body the SDK can parse.
+        /// The settings endpoint normally responds with "application/json", but data-residency
+        /// (region-prefixed) settings endpoints respond with "application/javascript" for the same
+        /// JSON body. Both are accepted so background settings polling succeeds for those accounts.
+        /// See https://github.com/wingify/vwo-fme-dotnet-sdk/issues/8
+        /// </summary>
+        public static bool IsJsonCompatibleContentType(string contentType)
+        {
+            if (string.IsNullOrEmpty(contentType))
+            {
+                return false;
+            }
+
+            return contentType.Contains("application/json") || contentType.Contains("application/javascript");
+        }
+
+        /// <summary>
         /// Makes a GET request to the given URL with retry logic
         /// </summary>
         /// <param name="requestModel"></param>
@@ -145,7 +162,7 @@ namespace WingifyFmeSdk.Packages.NetworkLayer.Client
 
                         string contentType = response.ContentType;
 
-                        if (statusCode >= ConstantsNamespace.Constants.HTTP_SUCCESS_MIN && statusCode <= ConstantsNamespace.Constants.HTTP_SUCCESS_MAX && contentType.Contains("application/json"))
+                        if (statusCode >= ConstantsNamespace.Constants.HTTP_SUCCESS_MIN && statusCode <= ConstantsNamespace.Constants.HTTP_SUCCESS_MAX && IsJsonCompatibleContentType(contentType))
                         {
                             string responseData = reader.ReadToEnd();
                             responseModel.SetData(responseData);


### PR DESCRIPTION
## What

Accept `application/javascript` (in addition to `application/json`) as a JSON-compatible response `Content-Type` in `NetworkClient.GET`.

Fixes #8.

## Why

For an account with data residency, after init the SDK region-prefixes the settings poll URL (`/{collectionPrefix}/server-side/v2-settings`). That endpoint returns **HTTP 200 with `Content-Type: application/javascript`** (the non-prefixed endpoint returns `application/json`) for the **same JSON body**. `NetworkClient.GET` only treated a response as successful when the `Content-Type` contained `application/json`, so every poll was rejected with `Invalid response. Status Code: 200, Response: OK`. As a result, background settings polling never refreshed settings for these accounts — dashboard changes only took effect after a process restart.

Full root-cause analysis is in #8.

## Change

- `NetworkClient.GET`: extracted the success `Content-Type` check into a new `public static bool NetworkClient.IsJsonCompatibleContentType(string contentType)` that accepts both `application/json` and `application/javascript` and is null-safe.
- Added `NetworkClientContentTypeTests` covering accepted (`application/json`, `application/javascript`, both with `charset`) and rejected (`text/html`, `text/plain`, `application/xml`, empty, `null`) content types.

## Testing

`dotnet test` — new tests pass (9 cases). No behavioural change for existing `application/json` responses.

## Notes

Events on `/{collectionPrefix}/server-side/batch-events-v2` are unaffected — only the settings `GET` path was impacted. An alternative/complementary fix would be for VWO to serve `Content-Type: application/json` on the region-prefixed settings endpoint.
